### PR TITLE
add installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,42 @@
+INSTALLATION
+============
+
+# Pre-requisites
+
+* PHP version 7.0 and above.
+* A [C++14](http://en.cppreference.com/w/cpp/compiler_support) capable compiler is required.
+
+
+# Binary packages
+
+## Windows
+
+DLL for Windows can be downloaded for the [PECL page](https://pecl.php.net/package/parle).
+
+## RPM
+
+RPM for Fedora, RHEL and CentOS can be installed from the [Remi repository](https://rpms.remirepo.net/).
+
+
+# Building from sources
+
+## From PECL
+
+Released versions can be installed using the ```pecl``` command:
+
+```
+pecl install parle-alpha
+```
+
+
+## From git
+
+Using a clone of this repository to retrieve latest developement sources:
+
+```
+git clone https://github.com/weltling/parle.git
+cd parle
+phpize
+./configure
+make
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ The implementation bases on the work of [Ben Hanson](http://www.benhanson.net/)
 
 Supported is PHP 7.0 and above. A [C++14](http://en.cppreference.com/w/cpp/compiler_support) capable compiler is required.
 
+
+Installation
+============
+
+Read the [INSTALL.md](./INSTALL.md) documentation.
+
+
 Example tokenizing comma separated integer list
 ============================================
 ```php

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,8 @@
 			<file role="src" name="parle.cpp"/>
 			<file role="doc" name="CREDITS"/>
 			<file role="doc" name="LICENSE"/>
+			<file role="doc" name="README.md"/>
+			<file role="src" name="INSTALL.md"/>
 			<file role="src" name="config.w32"/>
 			<file role="src" name="config.m4"/>
 			<dir name="lib">


### PR DESCRIPTION
I choose to have a separated INSTALL.md file, which is not installed (role="src") as this file is no more needed when installed. (for downstream, we are used to not package such file). INSTALL is a commonly used name.

With pointer to a "quite" famous repository ;)
