### PR TITLE
fix consistency of return type in 7.0/7.1/7.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -113,6 +113,7 @@
 				<file role="test" name="lexer_003.phpt"/>
 				<file role="test" name="lexer_003.json"/>
 				<file role="test" name="lexer_004.phpt"/>
+				<file role="test" name="reflection_001.phpt"/>
 				<file role="test" name="words_001.phpt"/>
 				<file role="test" name="words_002.phpt"/>
 			</dir>

--- a/parle.cpp
+++ b/parle.cpp
@@ -1283,20 +1283,22 @@ PHP_METHOD(ParleStack, top)
 /* {{{ Arginfo
  */
 
-#if PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION < 2
+#if PHP_VERSION_ID >= 70200
+
+#define PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX
+#define PARLE_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX  ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX
+
+#else
+
 #define PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
 	ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, NULL, allow_null)
-#elif PHP_MAJOR_VERSION >= 7
-#define PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX
+#define PARLE_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, classname, allow_null) \
+	ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, IS_OBJECT, #classname, allow_null)
+
 #endif
 
-#if PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION < 2
-PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_parle_lexer_gettoken, 0, 0, IS_OBJECT, 0)
+PARLE_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_parle_lexer_gettoken, 0, 0, Parle\\Token, 0)
 ZEND_END_ARG_INFO();
-#elif PHP_MAJOR_VERSION >= 7
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO(arginfo_parle_lexer_gettoken, "Parle\\Token", 0)
-ZEND_END_ARG_INFO();
-#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_parle_lexer_build, 0, 0, 0)
 ZEND_END_ARG_INFO();
@@ -1389,13 +1391,8 @@ ZEND_END_ARG_INFO();
 PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_parle_parser_trace, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO();
 
-#if PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION < 2
-PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_parle_parser_errorinfo, 0, 0, IS_OBJECT, 0)
+PARLE_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_parle_parser_errorinfo, 0, 0, Parle\\ErrorInfo, 0)
 ZEND_END_ARG_INFO();
-#elif PHP_MAJOR_VERSION >= 7
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO(arginfo_parle_parser_errorinfo, "Parle\\ErrorInfo", 0)
-ZEND_END_ARG_INFO();
-#endif
 
 PARLE_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_parle_stack_empty, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO();

--- a/tests/reflection_001.phpt
+++ b/tests/reflection_001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+return type in arg info
+--SKIPIF--
+<?php if (!extension_loaded("parle")) print "skip"; ?>
+--FILE--
+<?php 
+
+$r = new ReflectionMethod("Parle\\Lexer", "getToken");
+var_dump((string)$r->getReturnType());
+$r = new ReflectionMethod("Parle\\RLexer", "getToken");
+var_dump((string)$r->getReturnType());
+$r = new ReflectionMethod("Parle\\Parser", "errorInfo");
+var_dump((string)$r->getReturnType());
+
+?>
+==DONE==
+--EXPECTF--
+string(11) "Parle\Token"
+string(11) "Parle\Token"
+string(15) "Parle\ErrorInfo"
+==DONE==


### PR DESCRIPTION
Notice: I prefer PHP_VERSION_ID which seems more legible ;)

In PHP 7.0/7.1 reflection change:
```
-          - Return [ object ]
+          - Return [ Parle\Token ]
```

In PHP 7.2 reflection change:
```
-          - Return [ "Parle\\Token" ]
+          - Return [ Parle\Token ]
```
