### PR TITLE
fix PHP 8 compatibility

### DIFF
--- a/tests/reflection_002.phpt
+++ b/tests/reflection_002.phpt
@@ -74,9 +74,9 @@ try {
 
 ?>
 ==DONE==
---EXPECT--
-Argument 2 passed to Parle\Parser::validate() must be an instance of Parle\Lexer, instance of Parle\RLexer given
-Argument 2 passed to Parle\Parser::consume() must be an instance of Parle\Lexer, instance of Parle\RLexer given
-Argument 2 passed to Parle\RParser::validate() must be an instance of Parle\RLexer, instance of Parle\Lexer given
-Argument 2 passed to Parle\RParser::consume() must be an instance of Parle\RLexer, instance of Parle\Lexer given
+--EXPECTF--
+%s\Parser::validate()%s Parle\RLexer given
+%s\Parser::consume()%s Parle\RLexer given
+%s\RParser::validate()%s Parle\Lexer given
+%s\RParser::consume()%s Parle\Lexer given
 ==DONE==


### PR DESCRIPTION
Using PHP 8.0.1

```
=====================================================================
PASS Simple stackless calc [tests/calc_001.phpt] 
PASS Advanced calc with state [tests/calc_002.phpt] 
PASS Advanced calc with state [tests/calc_003.phpt] 
PASS Lex PHP var statement [tests/lexer_001.phpt] 
PASS Lex various number formats [tests/lexer_002.phpt] 
PASS Lex JSON [tests/lexer_003.phpt] 
PASS Restartable lexing [tests/lexer_004.phpt] 
PASS Lexer marker and cursor [tests/lexer_005.phpt] 
PASS Lexer token callback [tests/lexer_006.phpt] 
SKIP Lex JSON [tests/lexer_007.phpt] reason: reqire internal UTF-32
PASS Lexer flags [tests/lexer_flags.phpt] 
PASS Lexer functionality while it's used by parser [tests/lexer_position_tracking_001.phpt] 
PASS Lex test line property [tests/lexer_position_tracking_002.phpt] 
PASS return type in arg info [tests/reflection_001.phpt] 
PASS Test lexer/parser argument checking [tests/reflection_002.phpt] 
PASS Stack var_dump() [tests/stack_001.phpt] 
PASS Parse words from a string [tests/words_001.phpt] 
PASS Parse words from a string, UTF-8 regex [tests/words_002.phpt] 
SKIP Parse words from a string, UTF-8 regex [tests/words_003.phpt] reason: reqire internal UTF-32
=====================================================================

```