### PR TITLE
remove unneeded

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -8,7 +8,6 @@ PHP_ARG_ENABLE(parle-utf32, whether to enable internal UTF-32 support in parle,
 
 if test "$PHP_PARLE" != "no"; then
   PHP_REQUIRE_CXX()
-  PHP_ADD_LIBRARY(stdc++,,PARLE_SHARED_LIBADD)
 
   AC_DEFINE(HAVE_PARLE,1,[ ])
   PHP_SUBST(PARLE_SHARED_LIBADD)


### PR DESCRIPTION
libstdc++ doesn't have to be added, ad when g++ is properly invoked for link, this library is always there

And   
`PHP_NEW_EXTENSION(parle, parle.cpp, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -std=c++14, cxx)`

So C++ command (last option) is properly set and will be used.