### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/parle.cpp
+++ b/parle.cpp
@@ -3145,11 +3145,11 @@ PHP_MINIT_FUNCTION(parle)
 #endif
 
 	INIT_CLASS_ENTRY(ce, "Parle\\LexerException", NULL);
-	ParleLexerException_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	ParleLexerException_ce = zend_register_internal_class_ex(&ce, zend_ce_exception);
 	INIT_CLASS_ENTRY(ce, "Parle\\ParserException", NULL);
-	ParleParserException_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	ParleParserException_ce = zend_register_internal_class_ex(&ce, zend_ce_exception);
 	INIT_CLASS_ENTRY(ce, "Parle\\StackException", NULL);
-	ParleStackException_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	ParleStackException_ce = zend_register_internal_class_ex(&ce, zend_ce_exception);
 
 	REGISTER_NS_BOOL_CONSTANT("Parle", "INTERNAL_UTF32", PARLE_U32, CONST_PERSISTENT | CONST_CS);
 

--- a/tests/lexer_position_tracking_001.phpt
+++ b/tests/lexer_position_tracking_001.phpt
@@ -43,10 +43,10 @@ do {
 	case Parser::ACTION_REDUCE:
 		//echo "Trace: ", $par->trace(), PHP_EOL;
 		switch ($par->reduceId) {
-			case $prod_0;
+			case $prod_0:
 				echo " Match: '", $par->sigil(0), "', token: '", substr($in, $lex->marker, $lex->cursor - $lex->marker), "'", PHP_EOL;
 				break;
-			case $prod_1;
+			case $prod_1:
 				echo " Match: '", $par->sigil(1), "', token: '", substr($in, $lex->marker, $lex->cursor - $lex->marker), "'", PHP_EOL;
 				break;
 		}


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5